### PR TITLE
cargo binary conflict - rename 'fm' to 'fm-euclio' (or whatever you wish, to not conflict anymore!)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fm"
+name = "fm-euclio"
 version = "0.1.0"
 edition = "2021"
 authors = ["Andy Russell <arussell123@gmail.com>"]
@@ -7,7 +7,7 @@ publish = false
 license = "MIT"
 repository = "https://github.com/euclio/fm"
 homepage = "https://github.com/euclio/fm"
-description = "A small, general-purpose file manager."
+description = "fm-euclio is a small, general-purpose file manager built using GTK and Relm4."
 
 [dependencies]
 anyhow = "1.0.51"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 
 # Maintainer: Andy Russell <arussell123@gmail.com>
 
-pkgname=fm-git
+pkgname=fm-euclio-git
 pkgver=VERSION
 pkgrel=1
 pkgdesc="Small, general purpose file manager built with GTK"
@@ -11,7 +11,7 @@ license=('MIT')
 groups=()
 depends=('gtk4' 'libadwaita' 'libpanel' 'gtksourceview5')
 makedepends=('git' 'rust' 'cargo')
-provides=("fm")
+provides=("fm-euclio")
 conflicts=("fm")
 source=("git+$url")
 sha256sums=('SKIP')
@@ -37,6 +37,6 @@ check() {
 package() {
   cd "$srcdir/${pkgname%-git}"
 
-  install -Dm755 "$srcdir/${pkgname%-git}/target/release/fm" "$pkgdir/usr/bin/fm"
+  install -Dm755 "$srcdir/${pkgname%-git}/target/release/fm-euclio" "$pkgdir/usr/bin/fm-euclio"
   install -Dm644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname%-git}"
 }


### PR DESCRIPTION
There is something didn' t work with my attempt to compile after rename your project (to avoid cargo naming confict with existing `fm-gui` package)

Here is the full output:

```sh
$ cargo install --git https://github.com/dreamcat4/fm --branch fm-rename-to-fm-euclio
    Updating git repository `https://github.com/dreamcat4/fm`
  Installing fm-euclio v0.1.0 (https://github.com/dreamcat4/fm?branch=fm-rename-to-fm-euclio#3312e58f)
    Updating crates.io index
   Compiling serde v1.0.188
   Compiling equivalent v1.0.1
   Compiling hashbrown v0.14.1
   Compiling winnow v0.5.15
   Compiling heck v0.4.1
   Compiling target-lexicon v0.12.11
   Compiling smallvec v1.11.1
   Compiling pkg-config v0.3.27
   Compiling version-compare v0.1.1
   Compiling proc-macro2 v1.0.67
   Compiling unicode-ident v1.0.12
   Compiling autocfg v1.1.0
   Compiling libc v0.2.148
   Compiling version_check v0.9.4
   Compiling futures-core v0.3.28
   Compiling pin-project-lite v0.2.13
   Compiling syn v1.0.109
   Compiling anyhow v1.0.75
   Compiling once_cell v1.18.0
   Compiling proc-macro-error-attr v1.0.4
   Compiling slab v0.4.9
   Compiling futures-channel v0.3.28
   Compiling futures-sink v0.3.28
   Compiling futures-task v0.3.28
   Compiling proc-macro-error v1.0.4
   Compiling futures-util v0.3.28
   Compiling indexmap v2.0.1
   Compiling cfg-expr v0.15.5
   Compiling quote v1.0.33
   Compiling memchr v2.6.3
   Compiling pin-utils v0.1.0
   Compiling futures-io v0.3.28
   Compiling syn v2.0.37
   Compiling thiserror v1.0.49
   Compiling bitflags v1.3.2
   Compiling gio v0.17.10
   Compiling semver v1.0.19
   Compiling memoffset v0.9.0
   Compiling cfg-if v1.0.0
   Compiling num-traits v0.2.16
   Compiling tracing-core v0.1.31
   Compiling num-integer v0.1.45
   Compiling lock_api v0.4.10
   Compiling num-bigint v0.4.4
   Compiling scopeguard v1.2.0
   Compiling utf8parse v0.2.1
   Compiling lazy_static v1.4.0
   Compiling regex-syntax v0.6.29
   Compiling rustc_version v0.4.0
   Compiling regex-syntax v0.7.5
   Compiling rustix v0.38.14
   Compiling anstyle-parse v0.2.2
   Compiling field-offset v0.3.6
   Compiling getrandom v0.2.10
   Compiling log v0.4.20
   Compiling overload v0.1.1
   Compiling anstyle v1.0.4
   Compiling colorchoice v1.0.0
   Compiling anstyle-query v1.0.0
   Compiling linux-raw-sys v0.4.7
   Compiling async-trait v0.1.73
   Compiling bitflags v2.4.0
   Compiling anstream v0.6.1
   Compiling tracing-log v0.1.3
   Compiling nanorand v0.7.0
   Compiling nu-ansi-term v0.46.0
   Compiling regex-automata v0.3.8
   Compiling spin v0.9.8
   Compiling sharded-slab v0.1.6
   Compiling thread_local v1.1.7
   Compiling serde_spanned v0.6.3
   Compiling toml_datetime v0.6.3
   Compiling toml_edit v0.19.15
   Compiling regex-automata v0.1.10
   Compiling num_cpus v1.16.0
   Compiling clap_lex v0.5.1
   Compiling strsim v0.10.0
   Compiling matchers v0.1.0
   Compiling serde_json v1.0.107
   Compiling clap_builder v4.4.6
   Compiling tokio v1.32.0
   Compiling regex v1.9.5
   Compiling is-terminal v0.4.9
   Compiling dirs-sys v0.3.7
   Compiling toml v0.7.8
   Compiling system-deps v6.1.1
   Compiling proc-macro-crate v1.3.1
   Compiling fragile v2.0.0
   Compiling ryu v1.0.15
   Compiling either v1.9.0
   Compiling itoa v1.0.9
   Compiling directories v4.0.1
   Compiling pathdiff v0.2.1
   Compiling itertools v0.10.5
   Compiling mime v0.3.17
   Compiling futures-macro v0.3.28
   Compiling thiserror-impl v1.0.49
   Compiling glib-sys v0.17.10
   Compiling gobject-sys v0.17.10
   Compiling gio-sys v0.17.10
   Compiling cairo-sys-rs v0.17.10
   Compiling gdk-pixbuf-sys v0.17.10
   Compiling pango-sys v0.17.10
   Compiling graphene-sys v0.17.10
   Compiling glib-macros v0.17.10
   Compiling gdk4-sys v0.6.3
   Compiling gtk4-sys v0.6.3
   Compiling gsk4-sys v0.6.3
   Compiling libadwaita-sys v0.3.0
   Compiling gtk4-macros v0.6.6
   Compiling libpanel-sys v0.2.0
   Compiling tracing-attributes v0.1.26
   Compiling sourceview5-sys v0.6.0
   Compiling poppler-sys-rs v0.21.0
   Compiling pin-project-internal v1.1.3
   Compiling serde_derive v1.0.188
   Compiling clap_derive v4.4.2
   Compiling futures-executor v0.3.28
   Compiling futures v0.3.28
   Compiling relm4-macros v0.6.2
   Compiling enum-ordinalize v3.1.13
   Compiling pin-project v1.1.3
   Compiling flume v0.10.14
   Compiling tracing v0.1.37
   Compiling tracing-subscriber v0.3.17
   Compiling educe v0.4.23
   Compiling glib v0.17.10
   Compiling clap v4.4.6
   Compiling tracing-tree v0.2.4
   Compiling cairo-rs v0.17.10
   Compiling graphene-rs v0.17.10
   Compiling pango v0.17.10
   Compiling gdk-pixbuf v0.17.10
   Compiling poppler-rs v0.21.0
   Compiling gdk4 v0.6.3
   Compiling gsk4 v0.6.3
   Compiling gtk4 v0.6.6
   Compiling libadwaita v0.3.1
   Compiling libpanel v0.2.0
   Compiling sourceview5 v0.6.1
   Compiling relm4 v0.6.0-beta.1
   Compiling fm-euclio v0.1.0 (/home/id/.cargo/git/checkouts/fm-e5abaabeef82ee35/3312e58)
error[E0407]: method `output_to_parent_input` is not a member of trait `FactoryComponent`
   --> src/component/directory_list.rs:148:5
    |
148 | /     fn output_to_parent_input(output: Self::Output) -> Option<AppMsg> {
149 | |         Some(output)
150 | |     }
    | |_____^ not a member of trait `FactoryComponent`

error[E0308]: mismatched types
   --> src/component/app.rs:243:41
    |
243 |                 .launch_with_broker((), &ERROR_BROKER)
    |                  ------------------     ^^^^^^^^^^^^^ expected `&MessageBroker<AlertMsg>`, found `&MessageBroker<AlertModel>`
    |                  |
    |                  arguments to this method are incorrect
    |
    = note: expected reference `&MessageBroker<AlertMsg>`
               found reference `&MessageBroker<AlertModel>`
note: method defined here
   --> /home/id/.cargo/registry/src/index.crates.io-6f17d22bba15001f/relm4-0.6.0-beta.1/src/component/sync/builder.rs:151:12
    |
151 |     pub fn launch_with_broker(
    |            ^^^^^^^^^^^^^^^^^^

error[E0308]: mismatched types
   --> src/component/app.rs:259:26
    |
259 |         group.add_action(&about_action);
    |               ---------- ^^^^^^^^^^^^^ expected `RelmAction<_>`, found `&RelmAction<AboutAction>`
    |               |
    |               arguments to this method are incorrect
    |
    = note: expected struct `RelmAction<_>`
            found reference `&RelmAction<AboutAction>`
note: method defined here
   --> /home/id/.cargo/registry/src/index.crates.io-6f17d22bba15001f/relm4-0.6.0-beta.1/src/actions/mod.rs:219:12
    |
219 |     pub fn add_action<Name: ActionName>(&mut self, action: RelmAction<Name>) {
    |            ^^^^^^^^^^
help: consider removing the borrow
    |
259 -         group.add_action(&about_action);
259 +         group.add_action(about_action);
    |

error[E0308]: mismatched types
   --> src/component/app.rs:264:26
    |
264 |         group.add_action(&mount_action);
    |               ---------- ^^^^^^^^^^^^^ expected `RelmAction<_>`, found `&RelmAction<MountAction>`
    |               |
    |               arguments to this method are incorrect
    |
    = note: expected struct `RelmAction<_>`
            found reference `&RelmAction<MountAction>`
note: method defined here
   --> /home/id/.cargo/registry/src/index.crates.io-6f17d22bba15001f/relm4-0.6.0-beta.1/src/actions/mod.rs:219:12
    |
219 |     pub fn add_action<Name: ActionName>(&mut self, action: RelmAction<Name>) {
    |            ^^^^^^^^^^
help: consider removing the borrow
    |
264 -         group.add_action(&mount_action);
264 +         group.add_action(mount_action);
    |

error[E0308]: mismatched types
   --> src/component/directory_list.rs:555:22
    |
555 |       group.add_action(&RelmAction::<OpenDefaultAction>::new_with_target_value(
    |  ___________----------_^
    | |           |
    | |           arguments to this method are incorrect
556 | |         move |_, uri: String| {
557 | |             let _ = gio::AppInfo::launch_default_for_uri(&uri, None::<&gio::AppLaunchContext>);
558 | |         },
559 | |     ));
    | |_____^ expected `RelmAction<_>`, found `&RelmAction<OpenDefaultAction>`
    |
    = note: expected struct `RelmAction<_>`
            found reference `&RelmAction<directory_list::actions::OpenDefaultAction>`
note: method defined here
   --> /home/id/.cargo/registry/src/index.crates.io-6f17d22bba15001f/relm4-0.6.0-beta.1/src/actions/mod.rs:219:12
    |
219 |     pub fn add_action<Name: ActionName>(&mut self, action: RelmAction<Name>) {
    |            ^^^^^^^^^^
help: consider removing the borrow
    |
555 -     group.add_action(&RelmAction::<OpenDefaultAction>::new_with_target_value(
555 +     group.add_action(RelmAction::<OpenDefaultAction>::new_with_target_value(
    |

error[E0308]: mismatched types
   --> src/component/directory_list.rs:561:22
    |
561 |       group.add_action(&RelmAction::<OpenChooserAction>::new_with_target_value(
    |  ___________----------_^
    | |           |
    | |           arguments to this method are incorrect
562 | |         clone!(@strong sender => move |_, uri: String| {
563 | |             let file = gio::File::for_uri(&uri);
564 | |             sender.input(DirectoryMessage::ChooseAndLaunchApp(file));
565 | |         }),
566 | |     ));
    | |_____^ expected `RelmAction<_>`, found `&RelmAction<OpenChooserAction>`
    |
    = note: expected struct `RelmAction<_>`
            found reference `&RelmAction<directory_list::actions::OpenChooserAction>`
note: method defined here
   --> /home/id/.cargo/registry/src/index.crates.io-6f17d22bba15001f/relm4-0.6.0-beta.1/src/actions/mod.rs:219:12
    |
219 |     pub fn add_action<Name: ActionName>(&mut self, action: RelmAction<Name>) {
    |            ^^^^^^^^^^
help: consider removing the borrow
    |
561 -     group.add_action(&RelmAction::<OpenChooserAction>::new_with_target_value(
561 +     group.add_action(RelmAction::<OpenChooserAction>::new_with_target_value(
    |

error[E0308]: mismatched types
   --> src/component/directory_list.rs:573:22
    |
573 |       group.add_action(&RelmAction::<RenameAction>::new_with_target_value(
    |  ___________----------_^
    | |           |
    | |           arguments to this method are incorrect
574 | |         clone!(@weak rename_popover, @strong sender => move |_, uri: String| {
575 | |             let root = rename_popover.child().unwrap().downcast::<gtk::Box>().unwrap();
576 | |             let entry = root.first_child().unwrap().downcast::<gtk::Entry>().unwrap();
...   |
622 | |         }),
623 | |     ));
    | |_____^ expected `RelmAction<_>`, found `&RelmAction<RenameAction>`
    |
    = note: expected struct `RelmAction<_>`
            found reference `&RelmAction<directory_list::actions::RenameAction>`
note: method defined here
   --> /home/id/.cargo/registry/src/index.crates.io-6f17d22bba15001f/relm4-0.6.0-beta.1/src/actions/mod.rs:219:12
    |
219 |     pub fn add_action<Name: ActionName>(&mut self, action: RelmAction<Name>) {
    |            ^^^^^^^^^^
help: consider removing the borrow
    |
573 -     group.add_action(&RelmAction::<RenameAction>::new_with_target_value(
573 +     group.add_action(RelmAction::<RenameAction>::new_with_target_value(
    |

error[E0308]: mismatched types
   --> src/component/directory_list.rs:626:22
    |
626 |       group.add_action(&RelmAction::<TrashSelectionAction>::new_stateless(
    |  ___________----------_^
    | |           |
    | |           arguments to this method are incorrect
627 | |         move |_| sender_.input(DirectoryMessage::TrashSelection),
628 | |     ));
    | |_____^ expected `RelmAction<_>`, found `&RelmAction<TrashSelectionAction>`
    |
    = note: expected struct `RelmAction<_>`
            found reference `&RelmAction<directory_list::actions::TrashSelectionAction>`
note: method defined here
   --> /home/id/.cargo/registry/src/index.crates.io-6f17d22bba15001f/relm4-0.6.0-beta.1/src/actions/mod.rs:219:12
    |
219 |     pub fn add_action<Name: ActionName>(&mut self, action: RelmAction<Name>) {
    |            ^^^^^^^^^^
help: consider removing the borrow
    |
626 -     group.add_action(&RelmAction::<TrashSelectionAction>::new_stateless(
626 +     group.add_action(RelmAction::<TrashSelectionAction>::new_stateless(
    |

error[E0308]: mismatched types
   --> src/component/directory_list.rs:631:9
    |
630 |       group.add_action(
    |             ---------- arguments to this method are incorrect
631 | /         &RelmAction::<RestoreSelectionFromTrashAction>::new_stateless(move |_| {
632 | |             sender.input(DirectoryMessage::RestoreSelectionFromTrash)
633 | |         }),
    | |__________^ expected `RelmAction<_>`, found `&RelmAction<...>`
    |
    = note: expected struct `RelmAction<_>`
            found reference `&RelmAction<directory_list::actions::RestoreSelectionFromTrashAction>`
note: method defined here
   --> /home/id/.cargo/registry/src/index.crates.io-6f17d22bba15001f/relm4-0.6.0-beta.1/src/actions/mod.rs:219:12
    |
219 |     pub fn add_action<Name: ActionName>(&mut self, action: RelmAction<Name>) {
    |            ^^^^^^^^^^
help: consider removing the borrow
    |
631 -         &RelmAction::<RestoreSelectionFromTrashAction>::new_stateless(move |_| {
631 +         RelmAction::<RestoreSelectionFromTrashAction>::new_stateless(move |_| {
    |

error[E0308]: mismatched types
   --> src/component/directory_list.rs:649:22
    |
649 |       group.add_action(&RelmAction::<NewFolderAction>::new_stateless(move |_| {
    |  ___________----------_^
    | |           |
    | |           arguments to this method are incorrect
650 | |         sender.input(DirectoryMessage::ShowNewFolderDialog)
651 | |     }));
    | |______^ expected `RelmAction<_>`, found `&RelmAction<NewFolderAction>`
    |
    = note: expected struct `RelmAction<_>`
            found reference `&RelmAction<directory_list::actions::NewFolderAction>`
note: method defined here
   --> /home/id/.cargo/registry/src/index.crates.io-6f17d22bba15001f/relm4-0.6.0-beta.1/src/actions/mod.rs:219:12
    |
219 |     pub fn add_action<Name: ActionName>(&mut self, action: RelmAction<Name>) {
    |            ^^^^^^^^^^
help: consider removing the borrow
    |
649 -     group.add_action(&RelmAction::<NewFolderAction>::new_stateless(move |_| {
649 +     group.add_action(RelmAction::<NewFolderAction>::new_stateless(move |_| {
    |

error[E0308]: mismatched types
  --> src/component/new_folder_dialog.rs:89:43
   |
89 |                           ERROR_BROKER.send(AlertMsg::Show {
   |  ______________________________________----_^
   | |                                      |
   | |                                      arguments to this method are incorrect
90 | |                             text: e.to_string(),
91 | |                         });
   | |_________________________^ expected `AlertModel`, found `AlertMsg`
   |
note: method defined here
  --> /home/id/.cargo/registry/src/index.crates.io-6f17d22bba15001f/relm4-0.6.0-beta.1/src/component/message_broker.rs:55:12
   |
55 |     pub fn send(&self, input: M) {
   |            ^^^^

error[E0308]: mismatched types
   --> src/component/new_folder_dialog.rs:98:43
    |
98  |                           ERROR_BROKER.send(AlertMsg::Show {
    |  ______________________________________----_^
    | |                                      |
    | |                                      arguments to this method are incorrect
99  | |                             text: e.to_string(),
100 | |                         });
    | |_________________________^ expected `AlertModel`, found `AlertMsg`
    |
note: method defined here
   --> /home/id/.cargo/registry/src/index.crates.io-6f17d22bba15001f/relm4-0.6.0-beta.1/src/component/message_broker.rs:55:12
    |
55  |     pub fn send(&self, input: M) {
    |            ^^^^

Some errors have detailed explanations: E0308, E0407.
For more information about an error, try `rustc --explain E0308`.
error: could not compile `fm-euclio` (lib) due to 12 previous errors
warning: build failed, waiting for other jobs to finish...
error: failed to compile `fm-euclio v0.1.0 (https://github.com/dreamcat4/fm?branch=fm-rename-to-fm-euclio#3312e58f)`, intermediate artifacts can be found at `/tmp/cargo-installue4wQd`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
101 $ 
```